### PR TITLE
Correct Render static site type in blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ En profesjonell webapplikasjon for vurdering av solcellepotensial på næringsby
 
 - Se [Render-oppsett](docs/render-deployment.md) for en stegvis veiledning til både frontend og backend.
 - Render bygger og deployer automatisk fra GitHub-repositoriet ditt, så den tidligere GitHub Actions-workflowen for Vercel/Railway er ikke nødvendig.
+- Opprett tjenestene med `render.yaml`-blueprinten i rotmappen for å få riktige build-kommandoer (frontend: `npm install && npm run build`, backend: `npm install`).
 - Frontend kan også deployes på Vercel/Netlify, backend kan hostes på Railway/Heroku/Docker dersom du ønsker alternativer til Render.
 
 ## 🧪 Testing

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+services:
+  - type: web
+    name: solar-assessment-backend
+    env: node
+    plan: free
+    region: frankfurt
+    rootDir: backend
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: CORS_ORIGIN
+        value: https://solar-assessment-frontend.onrender.com
+      - key: MOCK_EXTERNAL_APIS
+        value: "false"
+  - type: static_site
+    name: solar-assessment-frontend
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    publishDir: build
+    envVars:
+      - key: REACT_APP_API_URL
+        value: https://solar-assessment-backend.onrender.com/api
+      - key: REACT_APP_ENVIRONMENT
+        value: production
+    headers:
+      - path: /*
+        name: Cache-Control
+        value: no-cache


### PR DESCRIPTION
## Summary
- correct the Render blueprint to use the `static_site` service type so the frontend build command is applied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e500f805808327a0f7fe141373ba37